### PR TITLE
Mirror of snoyberg http-client#390

### DIFF
--- a/http-conduit/ChangeLog.md
+++ b/http-conduit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.3.6
+
+* Add `httpSource` to `Network.HTTP.Client.Conduit` [#390](https://github.com/snoyberg/http-client/pull/390).
+
 ## 2.3.5
 
 * Adds `addToRequestQueryString` helper function

--- a/http-conduit/http-conduit.cabal
+++ b/http-conduit/http-conduit.cabal
@@ -1,5 +1,5 @@
 name:            http-conduit
-version:         2.3.5
+version:         2.3.6
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Mirror of snoyberg http-client#390
As the comment says, this is analogous to `Network.HTTP.Simple.httpSource`, but gets the manager from `MonadReader`.

The main idea is to provide a utility that idiomatically (through `bracketP`) links together the `responseOpen` and `responseClose` in a single conduit.
